### PR TITLE
pb_devices: Switch Redmi 7/Y3 device codename

### DIFF
--- a/pb_devices.json
+++ b/pb_devices.json
@@ -178,7 +178,7 @@
       "name": "Redmi 8",
       "maintainer": "Afiqqo"
     },
-    "onclite": {
+    "onc": {
       "name": "Redmi 7/Y3",
       "maintainer": "TheSync"
     },


### PR DESCRIPTION
We use "onc" as the default codename, at the same time this is also applied by XiaoMeme on MIUI