### PR TITLE
build.sh: Optimize CPU Threads for recovery build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -124,7 +124,7 @@ echo "Cleaning up the .repo, no use of it now"
 rm -rf .repo
 mkdir -p .repo && mv manifests .repo/ && ln -s .repo/manifests/default.xml .repo/manifest.xml
 
-/tmp/keepalive.sh & make -j6 recoveryimage
+/tmp/keepalive.sh & make -j${SYNCTHREAD} recoveryimage
 kill -s SIGTERM $(cat /tmp/keepalive.pid)
 echo -e "\nYummy Recovery is Served.\n"
 


### PR DESCRIPTION
- Forgot about this while fixing the repo-sync part.
  It will now use same thread counts as repo sync operation.