### PR TITLE
vendor_utils: Add Xiaomi Mi 9T/Redmi K20 (davinci,davinciin) to offici…

### DIFF
--- a/pb_devices.json
+++ b/pb_devices.json
@@ -190,6 +190,10 @@
       "name": "Xiaomi Mi A2 Lite",
       "maintainer": "PBRP Team"
     },
+    "davinci": {
+      "name": "Xiaomi Mi 9T/Redmi K20",
+      "maintainer": "ArixElo"
+    },
     "excalibur": {
       "name": "Xiaomi Redmi Note 9 Pro Max",
       "maintainer": "PBRP Team"


### PR DESCRIPTION
…al roaster

Signed-off-by: ArixElo <patroxgamer@gmail.com>
The GitHub Action on my tree is created, so if you have time please add this device to the official roaster.