### PR TITLE
pb_devices: Drop Xiaomi Mi 9T/Redmi K20 Official support

### DIFF
--- a/pb_devices.json
+++ b/pb_devices.json
@@ -254,10 +254,6 @@
       "name": "Xiaomi Mi A2 Lite",
       "maintainer": "PBRP Team"
     },
-    "davinci": {
-      "name": "Xiaomi Mi 9T/Redmi K20",
-      "maintainer": "ArixElo"
-    },
     "excalibur": {
       "name": "Xiaomi Redmi Note 9 Pro Max",
       "maintainer": "PBRP Team"


### PR DESCRIPTION
I don't have that device with me anymore, so I can't maintain PBRP for it.