### PR TITLE
Fix build error

### DIFF
--- a/build/tasks/pbrp.mk
+++ b/build/tasks/pbrp.mk
@@ -1,6 +1,6 @@
 WORK_PATH := $(OUT_DIR)/target/product/$(TARGET_DEVICE)/zip
-TARGET_DIR := $(WORK_PATH)/../
-BUILD_TOP := $(OUT_DIR)/../
+TARGET_DIR := $(WORK_PATH)/..
+BUILD_TOP := $(TOP)
 VERSION := $(shell cat $(BUILD_TOP)/bootable/recovery/variables.h | egrep "define\s+PB_MAIN_VERSION" | tr -d '"' | tr -s ' ' | awk '{ print $$3 }')
 PB_VENDOR := vendor/utils
 ifeq ($(PB_OFFICIAL),true)


### PR DESCRIPTION
Leaving a trailing slash in the path you defined is total blunder
Also Android build already has TOP var to get to tree top